### PR TITLE
Add fix for podspec git source attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,10 @@
+# sonos-objc CHANGELOG
+
+## 0.1.1
+
+Add git extension in podspec for git source attribute to allow podspec
+to pass linting.
+
+## 0.1.0
+
+Initial release.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ CocoaPods is a dependency manager for Objective-C, which automates and simplifie
 **Podfile**
 
 ```rb
-pod "sonos-objc", "~> 0.1.0"
+pod "sonos-objc", "~> 0.1.1"
 ```
 
 # Usage

--- a/sonos-objc.podspec
+++ b/sonos-objc.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "sonos-objc"
-  s.version      = "0.1.0"
+  s.version      = "0.1.1"
   s.description      = <<-EOL
     The aim of this library is to create a simple to use, yet useful API to control Sonos Devices via SOAP. It depends on AFNetworking (iOS and OS X) and XMLReader.h/m (iOS and OS X)
   EOL
@@ -8,7 +8,7 @@ Pod::Spec.new do |s|
   s.homepage     = "https://github.com/n1mda/sonos-objc"
   s.license      = 'MIT'
   s.author       = { "n1mda" => "axel@appreviation.se" }
-  s.source       = { :git => "https://github.com/n1mda/sonos-objc", :tag => s.version.to_s }
+  s.source       = { :git => "https://github.com/n1mda/sonos-objc.git", :tag => s.version.to_s }
 
   s.ios.deployment_target = '7.0'
   s.osx.deployment_target = '10.9'


### PR DESCRIPTION
In order to allow the podspec to lint properly, this commit adds the git
extension to the source url. It also adds a changelog to keep track of
changes across versions and updates the readme to show the latest
version of the pod.
